### PR TITLE
Correção de script de update

### DIFF
--- a/src/scripts/updatePortainer.py
+++ b/src/scripts/updatePortainer.py
@@ -21,7 +21,7 @@ with sync_playwright() as p:
     sleep(2)
     pagina.goto(page_stacks)
     sleep(2)
-    pagina.locator('a:has-text("inbcm-dev")').click()
+    pagina.locator('a:has-text("inbcm_dev")').click()
     sleep(2)
     pagina.locator('a:has-text("Editor")').click()
     sleep(2)


### PR DESCRIPTION
Essa alteração no script ocorre devido a mudança de nome da stack no portainer, assim corrigindo o ponteiro de update no ambiente.